### PR TITLE
Capitalize package name in bsconfig

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "reasongl",
+  "name": "Reasongl",
   "sources": [{
     "dir": "src",
     "subdirs": [{


### PR DESCRIPTION
This should fix trying to access js files at the wrong path on Linux.