### PR TITLE
Add `screen` and `play/pause` support

### DIFF
--- a/src/RGLInterface.re
+++ b/src/RGLInterface.re
@@ -14,7 +14,7 @@ module type t = {
     let getPixelWidth: t => int;
     let getPixelHeight: t => int;
     let getPixelScale: t => float;
-    let init: (~argv: array(string)) => t;
+    let init: (~screen: string=?, ~argv: array(string)) => t;
     let setWindowSize: (~window: t, ~width: int, ~height: int) => unit;
     let getContext: t => contextT;
   };
@@ -45,7 +45,7 @@ module type t = {
       ~displayFunc: float => unit,
       unit
     ) =>
-    unit;
+    bool => bool;
   type programT;
   type shaderT;
   let clearColor: (~context: contextT, ~r: float, ~g: float, ~b: float, ~a: float) => unit;

--- a/src/native/reasongl_native.re
+++ b/src/native/reasongl_native.re
@@ -86,7 +86,7 @@ module Gl: ReasonglInterface.Gl.t = {
     let getPixelWidth: t => int;
     let getPixelHeight: t => int;
     let getPixelScale: t => float;
-    let init: (~argv: array(string)) => t;
+    let init: (~screen: string=?, ~argv: array(string)) => t;
     let setWindowSize: (~window: t, ~width: int, ~height: int) => unit;
     let getContext: t => contextT;
   };
@@ -118,7 +118,8 @@ module Gl: ReasonglInterface.Gl.t = {
      * We create an OpenGL context at 2.1 because... it seems to be the only one that we can request that
      * osx will give us and one that has an API comparable to OpenGL ES 2.0 which is what WebGL uses.
      */
-    let init = (~argv as _) => {
+    let init = (~screen=?, ~argv as _) => {
+      /* Screen is ignored for now, we always just create a new window. */
       if (Sdl.Init.init(Sdl.Init.video lor Sdl.Init.audio) != 0) {
         failwith @@ Sdl.error()
       };
@@ -267,7 +268,9 @@ module Gl: ReasonglInterface.Gl.t = {
         tick()
       }
     };
-    tick()
+    tick();
+    /* No way to pause this externally, because we're the main loop */
+    (_ignored) => false
   };
   type programT = Gl.programT;
   type shaderT = Gl.shaderT;


### PR DESCRIPTION
This allows us to make render to multiple canvases & play / pause
screens to reduce CPU/GPU usage.

These changes don't currently apply to the native side of things

Test Plan:
This should be NFC for current programs. If no screenid is provided, or
of the provided id doesn't exist on the page, then a new canvas is
created as normal.