### PR TITLE
Basic Multi Touch Support

### DIFF
--- a/src/web/reasongl_web.re
+++ b/src/web/reasongl_web.re
@@ -68,13 +68,12 @@ let getTouch0 = (e, canvas) => {
 
 let getTouches = (e, canvas) => {
   let touches = convertToArray(getChangedTouches(e));
-  switch (touches) {
-  | ts => {
     let rect = getBoundingClientRect(canvas);
-    Array.map(t => (getTouchIdentifier(t), getClientX(t) - getLeft(rect), getClientY(t) - getTop(rect)), ts);
-  }
-  | _ => [||]
-  };
+    Array.map(t => (
+      getTouchIdentifier(t), 
+      getClientX(t) - getLeft(rect), 
+      getClientY(t) - getTop(rect)), 
+      touches);
 };
 
 [@bs.get] external getCanvasWidth : canvasT => int = "width";
@@ -229,7 +228,7 @@ module Gl: RGLInterface.t = {
       let node =
         switch (screen) {
         | None => None
-        | Some(id) => Js.Nullable.to_opt(Document.getElementById(id))
+        | Some(id) => Js.Nullable.toOption(Document.getElementById(id))
         };
       let canvas =
         switch (node) {
@@ -311,7 +310,6 @@ module Gl: RGLInterface.t = {
         ~displayFunc: float => unit,
         (),
       ) => {
-    let lastTouchId = ref(None);
     let touches = ref([]);
     let addTouch = touchId => {
       touches := List.exists(id => id == touchId, touches^) ? 


### PR DESCRIPTION
This builds upon the single touch support added in https://github.com/bsansouci/reasongl/commit/78995f20193557814bbe5fbdefeec270fd4da2bc

Related to: https://github.com/Schmavery/reprocessing/issues/47

As mentioned in the reprocessing issue, the existing solution doesn't handle multiple inputs and can become non-responsive. This fixes the issue by holding multiple touch points.

I am using this in ReTurbo here: https://github.com/RawToast/ReTurbo/pull/6 and on the current deployment: http://pale-potato.surge.sh. Just note the canvas touch positions are effected by #15 for larger devices.