### PR TITLE
get rid of deprecated to_opt warning

### DIFF
--- a/src/web/reasongl_web.ml
+++ b/src/web/reasongl_web.ml
@@ -163,7 +163,7 @@ module Gl : RGLInterface.t =
             match screen with
             | None -> None
             | ((Some (id))[@explicit_arity ]) ->
-                Js.Nullable.to_opt (Document.getElementById id) in
+                Js.Nullable.toOption(Document.getElementById id) in
           let canvas =
             match node with
             | ((Some (node))[@explicit_arity ]) -> Obj.magic node


### PR DESCRIPTION
When building the "web" example in https://github.com/bsansouci/reprocessing-example I get a deprecation warning message: `deprecated: Js.Nullable.to_opt
Use toOption instead`.

This change should get rid of that deprecation warning.
